### PR TITLE
feat: Edit health check string

### DIFF
--- a/src/interactive/export-apps.ts
+++ b/src/interactive/export-apps.ts
@@ -2,7 +2,7 @@ import enquirer from "enquirer";
 import { existsSync, writeFileSync } from "fs";
 import { configRowsToObj } from "../actions/update-config";
 import { getConfigMap, getDeployments, getService } from "../kube/kube-client";
-import { DOMAINS_ANNOTATION, FRUSTER_LIVENESS_ANNOTATION } from "../kube/kube-constants";
+import { DOMAINS_ANNOTATION } from "../kube/kube-constants";
 import { GLOBAL_CONFIG_NAME } from "../kube/kube-templates";
 import { AppManifest, ServiceRegistryModel } from "../models/ServiceRegistryModel";
 import { confirmPrompt, pressEnterToContinue, selectNamespace } from "../utils/cli-utils";
@@ -11,6 +11,7 @@ import {
 	getDeploymentContainerResources,
 	getDeploymentImage,
 	getNameAndNamespaceOrThrow,
+	getProbeString,
 } from "../utils/kube-utils";
 import { popScreen } from "./engine";
 
@@ -49,8 +50,6 @@ export async function exportApps() {
 			};
 		}
 
-		const hasFrusterHealth = !!(deployment.metadata?.annotations || {})[FRUSTER_LIVENESS_ANNOTATION];
-
 		const { config } = await getDeploymentAppConfig(deployment);
 
 		apps.push({
@@ -60,7 +59,7 @@ export async function exportApps() {
 			domains,
 			routable: !!svc,
 			resources: appResources,
-			livenessHealthCheck: hasFrusterHealth ? "fruster-health" : undefined,
+			livenessHealthCheck: getProbeString(deployment, "liveness"),
 		});
 	}
 

--- a/src/kube/kube-client.ts
+++ b/src/kube/kube-client.ts
@@ -158,7 +158,7 @@ export const createAppDeployment = async (
 		// Use existing number of replicas in update of deployment
 		replicas: existingDeployment ? existingDeployment.spec?.replicas : 1,
 		resources: serviceConfig.resources,
-		livenessHealthCheckType: serviceConfig.livenessHealthCheck,
+		livenessHealthCheck: serviceConfig.livenessHealthCheck,
 		changeCause: opts?.changeCause,
 		imagePullSecret: serviceConfig.imagePullSecret,
 		hasGlobalConfig: opts?.hasGlobalConfig,

--- a/src/kube/kube-constants.ts
+++ b/src/kube/kube-constants.ts
@@ -1,4 +1,3 @@
-export const FRUSTER_LIVENESS_ANNOTATION = "fruster.io/liveness-healthcheck";
 export const ROUTABLE_ANNOTATION = "router.deis.io/routable";
 export const DOMAINS_ANNOTATION = "router.deis.io/domains";
 export const CHANGE_CAUSE_ANNOTATION = "kubernetes.io/change-cause";

--- a/src/models/ServiceRegistryModel.ts
+++ b/src/models/ServiceRegistryModel.ts
@@ -21,5 +21,5 @@ export interface AppManifest {
 	};
 	env: any;
 	imagePullSecret?: string;
-	livenessHealthCheck?: "fruster-health" | "none";
+	livenessHealthCheck?: string;
 }

--- a/src/schemas/service-registry-schema.js
+++ b/src/schemas/service-registry-schema.js
@@ -97,12 +97,10 @@ module.exports = {
 					},
 					livenessHealthCheck: {
 						type: "string",
-						enum: ["fruster-health", "none"],
 						description:
-							"Type of liveness probe, defaults to `fruster-health` which will configure healt checks compatible with fruster-health-js",
+							"Type of liveness probe, examples:\ntcp=3000\nexec=cat /tmp/healthz\nget=:8080/healthz\n\nOptionally append ;initialDelaySeconds=60",
 					},
 				},
-
 				required: ["name"],
 			},
 		},


### PR DESCRIPTION
Adds functionality to parse liveness probe strings like this:

```
exec={command};initialDelaySeconds={sec}
get=:{port}{path};initialDelaySeconds={sec}
tcp={port};initialDelaySeconds={sec}
```